### PR TITLE
fix: move extended HIL tests inside hil_tests module

### DIFF
--- a/crates/gm65-scanner/src/driver/async_.rs
+++ b/crates/gm65-scanner/src/driver/async_.rs
@@ -627,7 +627,6 @@ pub mod hil_tests {
             }
         }
     }
-}
 
     async fn test_cancel_then_rescan<UART>(scanner: &mut Gm65ScannerAsync<UART>) -> bool
     where


### PR DESCRIPTION
## Summary

- Move 4 functions from top-level of `async_.rs` into the `hil_tests` module
- These functions used `defmt::` macros without being gated by the `defmt` feature
- The `hil_tests` module is already gated with `#[cfg(feature = "hil-tests")]` which implies `defmt`
- Fixes build failures when using `async` feature without `defmt`

## Background

When building the firmware with `--no-default-features` (to completely remove defmt/RTT for USB coexistence testing), gm65-scanner failed to compile because 4 extended HIL test functions used `defmt::info!/warn!/error!` without any cfg guard.

## Functions moved

- `test_cancel_then_rescan` 
- `test_rapid_triggers`
- `test_read_idle_no_trigger`
- `run_extended_hil_tests`

These are clearly HIL test code and belong inside the `hil_tests` module.