### PR TITLE
fix: USB OTG FS PHY reset for reliable re-enumeration after st-flash

### DIFF
--- a/examples/stm32f469i-disco/src/bin/async_firmware.rs
+++ b/examples/stm32f469i-disco/src/bin/async_firmware.rs
@@ -387,6 +387,52 @@ async fn init_peripherals() -> Peripherals {
     embassy_time::Timer::after(embassy_time::Duration::from_millis(500)).await;
     log_info!("Scanner UART ready (115200 baud, USART6 PG14=TX PG9=RX)");
 
+    // After a soft reset (SYSRESETREQ from st-flash), the USB OTG FS peripheral
+    // can be left in an inconsistent state where the PHY doesn't re-enumerate.
+    // Cycling the RCC clock + core soft reset + PHY power cycle ensures a clean
+    // start regardless of how we got here. See ccid-firmware-rs issue #15.
+    {
+        let rcc = stm32_metapac::RCC;
+
+        rcc.ahb2enr().modify(|w| w.set_otgfsen(false));
+        cortex_m::asm::delay(100);
+        rcc.ahb2enr().modify(|w| w.set_otgfsen(true));
+
+        rcc.ahb2rstr().modify(|w| w.set_otgfsrst(true));
+        cortex_m::asm::delay(100);
+        rcc.ahb2rstr().modify(|w| w.set_otgfsrst(false));
+        cortex_m::asm::delay(100);
+
+        // USB_OTG_FS_GLOBAL base: 0x5000_0000
+        // GRSTCTL offset: 0x010, GCCFG offset: 0x038
+        let otg_global = 0x5000_0000usize as *mut u32;
+        unsafe {
+            // GRSTCTL.AHBIDL (bit 31) — wait for AHB idle before reset
+            let mut timeout = 100_000u32;
+            while otg_global.add(0x010 / 4).read_volatile() & (1 << 31) == 0 {
+                timeout -= 1;
+                if timeout == 0 {
+                    break;
+                }
+            }
+
+            // GRSTCTL.CSRST (bit 0) — core soft reset, self-clearing
+            otg_global.add(0x010 / 4).write_volatile(1);
+            timeout = 100_000u32;
+            while otg_global.add(0x010 / 4).read_volatile() & 1 != 0 {
+                timeout -= 1;
+                if timeout == 0 {
+                    break;
+                }
+            }
+
+            // GCCFG.PWRDWN (bit 16) — PHY power cycle
+            otg_global.add(0x038 / 4).write_volatile(0);
+            cortex_m::asm::delay(100);
+            otg_global.add(0x038 / 4).write_volatile(1 << 16);
+        }
+    }
+
     let ep_out_buffer = USB_EP_OUT_BUF.init([0u8; USB_BUF_SIZE]);
     let mut usb_config = usb::Config::default();
     usb_config.vbus_detection = false;

--- a/examples/stm32f469i-disco/src/main.rs
+++ b/examples/stm32f469i-disco/src/main.rs
@@ -186,6 +186,52 @@ fn init_hardware() -> Hardware {
     render_boot_status(&mut fb, "[..] USB...", boot_line);
     boot_line += 1;
 
+    // After a soft reset (SYSRESETREQ from st-flash), the USB OTG FS peripheral
+    // can be left in an inconsistent state where the PHY doesn't re-enumerate.
+    // Cycling the RCC clock + core soft reset + PHY power cycle ensures a clean
+    // start regardless of how we got here. See ccid-firmware-rs issue #15.
+    {
+        let rcc_regs = unsafe { &*pac::RCC::ptr() };
+
+        rcc_regs.ahb2enr.modify(|_, w| w.otgfsen().clear_bit());
+        cortex_m::asm::delay(100);
+        rcc_regs.ahb2enr.modify(|_, w| w.otgfsen().set_bit());
+
+        rcc_regs.ahb2rstr.modify(|_, w| w.otgfsrst().set_bit());
+        cortex_m::asm::delay(100);
+        rcc_regs.ahb2rstr.modify(|_, w| w.otgfsrst().clear_bit());
+        cortex_m::asm::delay(100);
+
+        // USB_OTG_FS_GLOBAL base: 0x5000_0000
+        // GRSTCTL offset: 0x010, GCCFG offset: 0x038
+        let otg_global = 0x5000_0000usize as *mut u32;
+        unsafe {
+            // GRSTCTL.AHBIDL (bit 31) — wait for AHB idle before reset
+            let mut timeout = 100_000u32;
+            while otg_global.add(0x010 / 4).read_volatile() & (1 << 31) == 0 {
+                timeout -= 1;
+                if timeout == 0 {
+                    break;
+                }
+            }
+
+            // GRSTCTL.CSRST (bit 0) — core soft reset, self-clearing
+            otg_global.add(0x010 / 4).write_volatile(1);
+            timeout = 100_000u32;
+            while otg_global.add(0x010 / 4).read_volatile() & 1 != 0 {
+                timeout -= 1;
+                if timeout == 0 {
+                    break;
+                }
+            }
+
+            // GCCFG.PWRDWN (bit 16) — PHY power cycle
+            otg_global.add(0x038 / 4).write_volatile(0);
+            cortex_m::asm::delay(100);
+            otg_global.add(0x038 / 4).write_volatile(1 << 16);
+        }
+    }
+
     // USB CDC init
     let usb_periph = usb::init(
         (dp.OTG_FS_GLOBAL, dp.OTG_FS_DEVICE, dp.OTG_FS_PWRCLK),


### PR DESCRIPTION
## Summary

Fixes #56 — USB OTG FS doesn't re-enumerate after `st-flash` soft reset.

Adds explicit PHY reset to **both** firmware paths:

### Sync firmware (`main.rs`)
Uses bare-metal `stm32f4xx-hal` PAC for RCC register access before `usb::init()`.

### Async firmware (`async_firmware.rs`)
Uses `stm32_metapac::RCC` for register access before `usb::Driver::new_fs()`.

## Reset Sequence (both paths)

1. RCC AHB2ENR.OTGFSEN clock cycle (disable → enable)
2. RCC AHB2RSTR.OTGFSRST peripheral reset (assert → deassert)
3. GRSTCTL.CSRST core soft reset
4. GCCFG.PWRDWN PHY power cycle (clear → set)

## Why This Is Needed

After `st-flash` (SYSRESETREQ without NRST), the USB PHY retains stale state. Neither the bare-metal `synopsys-usb-otg` crate nor `embassy-usb-synopsys-otg` performs the full reset sequence needed to unwedge the PHY.

## Verification

Same fix hardware-verified on STM32F746-DISCO in ccid-firmware-rs (commit 28e6fee, issue #15). The STM32F469 uses an identical OTG FS peripheral at the same base address (0x5000_0000).

## Related

- ccid-firmware-rs#15 — original fix (STM32F746, hardware-verified)
- Amperstrand/microfips#105 — same fix for microfips
- Amperstrand/micronuts#34 — same fix for micronuts